### PR TITLE
change app register url

### DIFF
--- a/go/github_sample/sample_1.go
+++ b/go/github_sample/sample_1.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	// You must register the app at https://github.com/settings/applications
+	// You must register the app at https://github.com/settings/developers
 	// Set callback to http://127.0.0.1:7000/github_oauth_cb
 	// Set ClientId and ClientSecret to
 	oauthConf = &oauth2.Config{


### PR DESCRIPTION
`https://github.com/settings/applications` is a list of apps that user grant access to his account. The correct address is `https://github.com/settings/developers`